### PR TITLE
Update check-large-objects.sh to be language neutral

### DIFF
--- a/utils/check-style/check-large-objects.sh
+++ b/utils/check-style/check-large-objects.sh
@@ -12,7 +12,7 @@ TU_EXCLUDES=(
     Aggregator
 )
 
-if find $1 -name '*.o' | xargs wc -c | grep -v total | sort -rn | awk '{ if ($1 > 50000000) print }' \
+if find $1 -name '*.o' | xargs wc -c | grep --regexp='.o$' | sort -rn | awk '{ if ($1 > 50000000) print }' \
     | grep -v -f <(printf "%s\n" "${TU_EXCLUDES[@]}")
 then
     echo "^ It's not allowed to have so large translation units."


### PR DESCRIPTION
The previous implementation uses `total` keyword to filter out lines that contains the total size of objects under a directory. But when the OS uses other language, it fails to filter out that line, so the script would fail. 

This implementation changes the script to match only lines that contains object file by their extension. This implementation would be language neutral.

This fixes https://github.com/ClickHouse/ClickHouse/issues/58401.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Bug Fix (user-visible misbehavior in an official stable release)
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
